### PR TITLE
fix: generate resume only if no resume flag was provided

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-from pathlib import Path
 import yaml
 import click
 from selenium import webdriver
@@ -165,9 +164,12 @@ def create_and_run_bot(parameters, llm_api_key):
             plain_text_resume = file.read()
         resume_object = Resume(plain_text_resume)
         resume_generator_manager = FacadeManager(llm_api_key, style_manager, resume_generator, resume_object, Path("data_folder/output"))
-        os.system('cls' if os.name == 'nt' else 'clear')
-        resume_generator_manager.choose_style()
-        os.system('cls' if os.name == 'nt' else 'clear')
+                # generate resume only if no resume flag was provided
+        if "resume" not in parameters["uploads"]:
+            os.system("cls" if os.name == "nt" else "clear")
+            resume_generator_manager.choose_style()
+            os.system("cls" if os.name == "nt" else "clear")
+
         
         job_application_profile_object = JobApplicationProfile(plain_text_resume)
         

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from pathlib import Path
 import yaml
 import click
 from selenium import webdriver


### PR DESCRIPTION
There was an issue that even if I provide `--resume` flag, it still asks me which style I would like to use for my resume. I made this prompt to only appear if no resume flag was provided