### PR TITLE
🔀[aihawl_easy_applier.py] fixed saving duplicate questions to answers.json

### DIFF
--- a/src/aihawk_easy_applier.py
+++ b/src/aihawk_easy_applier.py
@@ -820,6 +820,13 @@ class AIHawkEasyApplier:
     def _save_questions_to_json(self, question_data: dict) -> None:
         output_file = 'answers.json'
         question_data['question'] = self._sanitize_text(question_data['question'])
+
+        # Check if the question already exists in the JSON file and bail out if it does
+        for item in self.all_data:
+            if self._sanitize_text(item['question']) == question_data['question'] and item['type'] == question_data['type']:
+                logger.debug(f"Question already exists in answers.json. Aborting save of: {item['question']}")
+                return
+
         logger.debug(f"Saving question data to JSON: {question_data}")
         try:
             try:
@@ -837,6 +844,7 @@ class AIHawkEasyApplier:
             data.append(question_data)
             with open(output_file, 'w') as f:
                 json.dump(data, f, indent=4)
+                self.all_data.append(question_data)
             logger.debug("Question data saved successfully to JSON")
         except Exception:
             tb_str = traceback.format_exc()

--- a/src/aihawk_easy_applier.py
+++ b/src/aihawk_easy_applier.py
@@ -844,7 +844,7 @@ class AIHawkEasyApplier:
             data.append(question_data)
             with open(output_file, 'w') as f:
                 json.dump(data, f, indent=4)
-                self.all_data.append(question_data)
+                self.all_data = data
             logger.debug("Question data saved successfully to JSON")
         except Exception:
             tb_str = traceback.format_exc()


### PR DESCRIPTION
fixed #557

`class AIHawkEasyApplier`'s `_save_questions_to_json()` method now checks if the question has already been saved with an answer, and aborts the new save request if so. Preventing duplicated of the same question being saved.