### PR TITLE
fix issue: #457. Premium user's can't find descriptions.

### DIFF
--- a/src/aihawk_easy_applier.py
+++ b/src/aihawk_easy_applier.py
@@ -232,7 +232,12 @@ class AIHawkEasyApplier:
             except NoSuchElementException:
                 logger.debug("See more button not found, skipping")
 
-            description = self.driver.find_element(By.CLASS_NAME, 'jobs-description-content__text').text
+            try:
+                description = self.driver.find_element(By.CLASS_NAME, 'jobs-description-content__text').text
+            except NoSuchElementException:
+                logger.debug("First class not found, checking for second class for premium members")
+                description = self.driver.find_element(By.CLASS_NAME, 'job-details-about-the-job-module__description').text
+
             logger.debug("Job description retrieved successfully")
             return description
         except NoSuchElementException:


### PR DESCRIPTION
Fix for issue https://github.com/feder-cr/Auto_Jobs_Applier_AIHawk/issues/457:

When user is a LinkedIn premium user, the description is not found. See issue 457 for examples. The proposed fix first checks for the original class name used in non premium LinkedIn and if the element is not found then it searches for the Premium version of  LinkedIn's class name. Tested with my Premium version of LinkdIn and it works. Also proposing this gets merged to v4 obviously which also has the same bug here:
https://github.com/feder-cr/Auto_Jobs_Applier_AIHawk/blob/dceae26382bb8a931c43bc3e574414e57c29722a/src/aihawk_easy_applier.py#L374