### PR TITLE
Fix case sensitivity in blacklist comparisons for job titles

### DIFF
--- a/src/aihawk_job_manager.py
+++ b/src/aihawk_job_manager.py
@@ -470,7 +470,7 @@ class AIHawkJobManager:
     def is_blacklisted(self, job_title, company, link):
         logger.debug(f"Checking if job is blacklisted: {job_title} at {company}")
         job_title_words = job_title.lower().split(' ')
-        title_blacklisted = any(word in job_title_words for word in self.title_blacklist)
+        title_blacklisted = any(word in job_title_words for word in map(str.lower, self.title_blacklist))
         company_blacklisted = company.strip().lower() in (word.strip().lower() for word in self.company_blacklist)
         link_seen = link in self.seen_jobs
         is_blacklisted = title_blacklisted or company_blacklisted or link_seen


### PR DESCRIPTION
This commit fixes an issue where blacklist checks for job titles were case-sensitive. Now, job titles are compared in lowercase to ensure correct matches regardless of uppercase or lowercase usage. The map(str.lower, ...) function was added to convert blacklist words for job titles to lowercase, ensuring consistent comparison.

Additionally, excessive HTML logs are making it difficult to debug the application effectively, which should be addressed in future commits to improve clarity during debugging.