### PR TITLE
Add cover letter functionality

### DIFF
--- a/data_folder/plain_text_resume.yaml
+++ b/data_folder/plain_text_resume.yaml
@@ -128,3 +128,5 @@ work_preferences:
   willing_to_complete_assessments: "[Yes/No]"
   willing_to_undergo_drug_tests: "[Yes/No]"
   willing_to_undergo_background_checks: "[Yes/No]"
+
+cover_letter: "[Your Cover Letter]"

--- a/data_folder_example/plain_text_resume.yaml
+++ b/data_folder_example/plain_text_resume.yaml
@@ -137,3 +137,5 @@ work_preferences:
   willing_to_complete_assessments: "Yes"
   willing_to_undergo_drug_tests: "Yes"
   willing_to_undergo_background_checks: "Yes"
+
+cover_letter: "I am writing to express my interest in the Software Engineer position at your esteemed company. With a strong background in software development and a passion for creating innovative solutions, I am confident in my ability to contribute to your team. My experience includes developing web applications using React and Node.js, collaborating with cross-functional teams, and troubleshooting complex software issues. I am excited about the opportunity to bring my skills and enthusiasm to your organization. Thank you for considering my application."

--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ class FileManager:
         return (app_data_folder / 'secrets.yaml', app_data_folder / 'config.yaml', app_data_folder / 'plain_text_resume.yaml', output_folder)
 
     @staticmethod
-    def file_paths_to_dict(resume_file: Path | None, plain_text_resume_file: Path) -> dict:
+    def file_paths_to_dict(resume_file: Path | None, plain_text_resume_file: Path, cover_letter_file: Path | None = None) -> dict:
         if not plain_text_resume_file.exists():
             raise FileNotFoundError(f"Plain text resume file not found: {plain_text_resume_file}")
 
@@ -146,6 +146,11 @@ class FileManager:
             if not resume_file.exists():
                 raise FileNotFoundError(f"Resume file not found: {resume_file}")
             result['resume'] = resume_file
+
+        if cover_letter_file:
+            if not cover_letter_file.exists():
+                raise FileNotFoundError(f"Cover letter file not found: {cover_letter_file}")
+            result['coverLetter'] = cover_letter_file
 
         return result
 
@@ -194,8 +199,9 @@ def create_and_run_bot(parameters, llm_api_key):
 
 @click.command()
 @click.option('--resume', type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path), help="Path to the resume PDF file")
+@click.option('--cover_letter', type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path), help="Path to the cover letter file")
 @click.option('--collect', is_flag=True, help="Only collects data job information into data.json file")
-def main(collect: False, resume: Path = None):
+def main(collect: False, resume: Path = None, cover_letter: Path = None):
     try:
         data_folder = Path("data_folder")
         secrets_file, config_file, plain_text_resume_file, output_folder = FileManager.validate_data_folder(data_folder)
@@ -203,7 +209,7 @@ def main(collect: False, resume: Path = None):
         parameters = ConfigValidator.validate_config(config_file)
         llm_api_key = ConfigValidator.validate_secrets(secrets_file)
         
-        parameters['uploads'] = FileManager.file_paths_to_dict(resume, plain_text_resume_file)
+        parameters['uploads'] = FileManager.file_paths_to_dict(resume, plain_text_resume_file, cover_letter)
         parameters['outputFileDirectory'] = output_folder
         parameters['collectMode'] = collect
         

--- a/src/aihawk_easy_applier.py
+++ b/src/aihawk_easy_applier.py
@@ -434,7 +434,11 @@ class AIHawkEasyApplier:
                     self._create_and_upload_resume(element, job)
             elif 'cover' in output:
                 logger.debug("Uploading cover letter")
-                self._create_and_upload_cover_letter(element, job)
+                if job.cover_letter_path is not None and os.path.exists(job.cover_letter_path):
+                    element.send_keys(job.cover_letter_path)
+                    logger.debug(f"Cover letter uploaded from path: {job.cover_letter_path}")
+                else:
+                    self._create_and_upload_cover_letter(element, job)
 
         logger.debug("Finished handling upload fields")
 

--- a/src/job_application_profile.py
+++ b/src/job_application_profile.py
@@ -62,6 +62,7 @@ class JobApplicationProfile:
     work_preferences: WorkPreferences
     availability: Availability
     salary_expectations: SalaryExpectations
+    cover_letter: str
 
     def __init__(self, yaml_str: str):
         logger.debug("Initializing JobApplicationProfile with provided YAML string")
@@ -169,6 +170,15 @@ class JobApplicationProfile:
             logger.error(f"An unexpected error occurred while processing salary_expectations: {e}")
             raise RuntimeError("An unexpected error occurred while processing salary_expectations.") from e
 
+        # Process cover_letter
+        try:
+            logger.debug("Processing cover_letter")
+            self.cover_letter = data.get('cover_letter', '')
+            logger.debug(f"cover_letter processed: {self.cover_letter}")
+        except Exception as e:
+            logger.error(f"An unexpected error occurred while processing cover_letter: {e}")
+            raise RuntimeError("An unexpected error occurred while processing cover_letter.") from e
+
         logger.debug("JobApplicationProfile initialization completed successfully.")
 
     def __str__(self):
@@ -181,6 +191,7 @@ class JobApplicationProfile:
                          f"Legal Authorization:\n{format_dataclass(self.legal_authorization)}\n\n"
                          f"Work Preferences:\n{format_dataclass(self.work_preferences)}\n\n"
                          f"Availability: {self.availability.notice_period}\n\n"
-                         f"Salary Expectations: {self.salary_expectations.salary_range_usd}\n\n")
+                         f"Salary Expectations: {self.salary_expectations.salary_range_usd}\n\n"
+                         f"Cover Letter: {self.cover_letter}\n\n")
         logger.debug(f"String representation generated: {formatted_str}")
         return formatted_str


### PR DESCRIPTION
Fixes #614

Add functionality to specify a specific cover letter for job applications.

* **main.py**
  - Add `cover_letter` option to the `main` function to specify a cover letter file.
  - Update `FileManager.file_paths_to_dict` method to handle the `cover_letter` file.
  - Pass the `cover_letter` file to the `create_and_run_bot` function.

* **src/aihawk_easy_applier.py**
  - Update `_handle_upload_fields` method to handle the `cover_letter` file.
  - Add logic to upload cover letter from the specified path if it exists.

* **src/job_application_profile.py**
  - Add `cover_letter` attribute to the `JobApplicationProfile` class.
  - Update `__init__` method to initialize the `cover_letter` attribute.

* **data_folder_example/plain_text_resume.yaml**
  - Add `cover_letter` field with example content.

* **data_folder/plain_text_resume.yaml**
  - Add `cover_letter` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/feder-cr/Auto_Jobs_Applier_AIHawk/issues/614?shareId=b4ec2c66-5d15-4e31-891c-7601b82ce8e7).