### PR TITLE
Urgent fix issue in #648

### DIFF
--- a/src/aihawk_job_manager.py
+++ b/src/aihawk_job_manager.py
@@ -513,6 +513,10 @@ class AIHawkJobManager:
         file_name = "failed"
         file_path = self.output_file_directory / f"{file_name}.json"
 
+        if not file_path.exists():
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump([], f)
+                
         with open(file_path, 'r', encoding='utf-8') as f:
             try:
                 existing_data = json.load(f)


### PR DESCRIPTION
This is an urgent fix because the absence of the failed.json file prevents the script from running. The issue has already been fixed in the release branch. Now, we are urgently syncing it to the main branch.