### PR TITLE
enabled using any OpenAI API compatible endpoint

### DIFF
--- a/src/llm/llm_manager.py
+++ b/src/llm/llm_manager.py
@@ -31,9 +31,10 @@ class AIModel(ABC):
 
 
 class OpenAIModel(AIModel):
-    def __init__(self, api_key: str, llm_model: str):
+    def __init__(self, api_key: str, llm_model: str, url: str):
         from langchain_openai import ChatOpenAI
         self.model = ChatOpenAI(model_name=llm_model, openai_api_key=api_key,
+                                base_url=url,
                                 temperature=0.4)
 
     def invoke(self, prompt: str) -> BaseMessage:
@@ -116,7 +117,7 @@ class AIAdapter:
         logger.debug(f"Using {llm_model_type} with {llm_model}")
 
         if llm_model_type == "openai":
-            return OpenAIModel(api_key, llm_model)
+            return OpenAIModel(api_key, llm_model, llm_api_url)
         elif llm_model_type == "claude":
             return ClaudeModel(api_key, llm_model)
         elif llm_model_type == "ollama":

--- a/src/llm/llm_manager.py
+++ b/src/llm/llm_manager.py
@@ -31,11 +31,18 @@ class AIModel(ABC):
 
 
 class OpenAIModel(AIModel):
-    def __init__(self, api_key: str, llm_model: str, url: str):
+    def __init__(self, api_key: str, llm_model: str, url: str = ""):
         from langchain_openai import ChatOpenAI
-        self.model = ChatOpenAI(model_name=llm_model, openai_api_key=api_key,
-                                base_url=url,
-                                temperature=0.4)
+        kwargs = {
+            'model_name': llm_model,
+            'openai_api_key': api_key,
+            'temperature': 0.4
+        }
+        
+        if url:
+            kwargs['base_url'] = url
+        
+        self.model = ChatOpenAI(**kwargs)
 
     def invoke(self, prompt: str) -> BaseMessage:
         logger.debug("Invoking OpenAI API")


### PR DESCRIPTION
passing in the base_url to the ChatOpenAI init lets this use any OpenAI API compatible server.

For example, this let me use vLLM as a backend:
llm_model_type: openai
llm_model: "Qwen/Qwen2.5-72B-Instruct-AWQ"
llm_api_url: "http://0.0.0.0:8000/v1"