### PR TITLE
Fix experience level key to enable filtering in search

### DIFF
--- a/src/aihawk_job_manager.py
+++ b/src/aihawk_job_manager.py
@@ -420,7 +420,7 @@ class AIHawkJobManager:
         url_parts = []
         if parameters['remote']:
             url_parts.append("f_CF=f_WRA")
-        experience_levels = [str(i + 1) for i, (level, v) in enumerate(parameters.get('experience_level', {}).items()) if
+        experience_levels = [str(i + 1) for i, (level, v) in enumerate(parameters.get('experienceLevel', {}).items()) if
                              v]
         if experience_levels:
             url_parts.append(f"f_E={','.join(experience_levels)}")


### PR DESCRIPTION
### Summary
Corrected the key used to access experience levels in the parameters dictionary from 'experience_level' to 'experienceLevel'. This change allows the experience level filter to work properly during searches, returning the expected results.

### Related Issue

Fixes #696