### PR TITLE
Hotfix - Fix get_base_search_url method to build valid date query

### DIFF
--- a/src/ai_hawk/job_manager.py
+++ b/src/ai_hawk/job_manager.py
@@ -440,10 +440,10 @@ class AIHawkJobManager:
         if job_types:
             url_parts.append(f"f_JT={','.join(job_types)}")
         date_mapping = {
-            "all time": "",
+            "all_time": "",
             "month": "&f_TPR=r2592000",
             "week": "&f_TPR=r604800",
-            "24 hours": "&f_TPR=r86400"
+            "24_hours": "&f_TPR=r86400"
         }
         date_param = next((v for k, v in date_mapping.items() if parameters.get('date', {}).get(k)), "")
         url_parts.append("f_LF=f_AL")  # Easy Apply

--- a/tests/test_aihawk_job_manager.py
+++ b/tests/test_aihawk_job_manager.py
@@ -41,7 +41,7 @@ def test_set_parameters(mocker, job_manager):
         },
         'remote': False,
         'distance': 50,
-        'date': {'all time': True}
+        'date': {'all_time': True}
     }
 
     job_manager.set_parameters(params)


### PR DESCRIPTION
### Issue
With the merge of PR #671 the `get_base_search_url` in `AIHawkJobManager` broke because the updated date mappings were not incorporated in the function. As a result, the function was unable to build the correct base query and defaulted to searching for jobs posted "all time."


### Fix
- Updated the `date_mapping` object to utilize the new YAML values, which rectifies the function to build the query as intended.


### Verification Process
Tested on local and is working as expected.
