### PR TITLE
[Fixed issue #696] Incorrect key for experienceLevel

### DIFF
--- a/src/aihawk_job_manager.py
+++ b/src/aihawk_job_manager.py
@@ -420,7 +420,7 @@ class AIHawkJobManager:
         url_parts = []
         if parameters['remote']:
             url_parts.append("f_CF=f_WRA")
-        experience_levels = [str(i + 1) for i, (level, v) in enumerate(parameters.get('experience_level', {}).items()) if
+        experience_levels = [str(i + 1) for i, (level, v) in enumerate(parameters.get('experienceLevel', {}).items()) if
                              v]
         if experience_levels:
             url_parts.append(f"f_E={','.join(experience_levels)}")


### PR DESCRIPTION
The key name for experience level in get_base_search_url() is not consistent with the name in config.yaml.